### PR TITLE
Change the data type of tv_sec

### DIFF
--- a/src/c/scheduler.c
+++ b/src/c/scheduler.c
@@ -75,7 +75,7 @@ static uint64_t getTimeAsUInt64 (void)
 {
   struct timespec ts;
   clock_gettime (CLOCK_REALTIME, &ts);
-  return (uint64_t) (ts.tv_sec * IOT_BILLION + ts.tv_nsec);
+  return (uint64_t)ts.tv_sec * IOT_BILLION + ts.tv_nsec;
 }
 
 /* Scheduler Thread */


### PR DESCRIPTION
The vaule of "ts.tv_sec * IOT_BILLION"  is data overflow on ARM32.
To fix this problem change the data type of ts_sec.

Reported-by: Sun Lianwen <sunlianwen@sgepri.sgcc.com.cn>
Signed-off-by: Wei Xingshen <weixingshen@sgepri.sgcc.com.cn>