### PR TITLE
XRT-177 Update to support static typecodes for array types

### DIFF
--- a/src/c/utests/scheduler/scheduler.c
+++ b/src/c/utests/scheduler/scheduler.c
@@ -250,6 +250,7 @@ static void cunit_scheduler_delete (void)
 
   iot_schedule_delete (scheduler, sched5);
   iot_scheduler_stop (scheduler);
+  iot_threadpool_wait (pool);
 
   CU_ASSERT (atomic_load (&sum_test) == 1u)
   CU_ASSERT (atomic_load (&sum_work5) > 20u)


### PR DESCRIPTION
This update helps with adding typecode support to the device sdk in XRT. Means that don't have
to bother freeing basic and array typecodes.