### PR TITLE
XRT-411: Removed spinlock.

### DIFF
--- a/src/c/data.c
+++ b/src/c/data.c
@@ -14,7 +14,7 @@
 #endif
 
 #if defined (_GNU_SOURCE) || defined (_ALPINE_)
-#define IOT_HAS_SPINLOCK
+// #define IOT_HAS_SPINLOCK
 #endif
 
 #if defined (NDEBUG) || defined (_AZURESPHERE_)


### PR DESCRIPTION
Spinlock is no longer a suitable choice as iot_data_block_alloc can invoke calloc while lock is held.