### PR TITLE
XRT-1286:  Enable arm32 build on Ubuntu20.04

### DIFF
--- a/scripts/Dockerfile.ubuntu-20.04
+++ b/scripts/Dockerfile.ubuntu-20.04
@@ -3,10 +3,10 @@ ENV SYSTEM="ubuntu-20.04"
 LABEL MAINTAINER="IOTech <support@iotechsys.com>"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
-RUN apt-get update && apt-get install -y unzip build-essential file wget git gcc cmake make valgrind cppcheck lcov doxygen graphviz uuid-dev python3-pip ruby-dev
+RUN apt-get update && apt-get install -y unzip build-essential file wget git gcc cmake make valgrind cppcheck lcov doxygen graphviz uuid-dev python3-pip ruby-dev libxml2-dev libxslt1-dev zlib1g-dev
 RUN dpkg-reconfigure --frontend noninteractive tzdata
 RUN gem install --no-document fpm
-RUN pip3 install gcovr
+RUN pip3 install lxml gcovr
 COPY VERSION /iotech-iot/
 COPY RELEASE_NOTES.md /iotech-iot/
 COPY src /iotech-iot/src/

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -2,7 +2,7 @@
 
 systems_x86_64 = ['ubuntu-20.04','ubuntu-18.04','alpine-3.14','alpine-3.15','debian-11','debian-10','fedora-35','opensuse-15.3','photon-40','zephyr-2.3','clearlinux','azuresphere-11'] as String[]
 systems_arm64 = ['ubuntu-20.04','ubuntu-18.04','alpine-3.14','alpine-3.15','debian-11','debian-10','fedora-35','opensuse-15.3','photon-40'] as String[]
-systems_arm32 = ['ubuntu-18.04','alpine-3.14','alpine-3.15','debian-11','debian-10','opensuse-15.3'] as String[]
+systems_arm32 = ['ubuntu-20.04','ubuntu-18.04','alpine-3.14','alpine-3.15','debian-11','debian-10','opensuse-15.3'] as String[]
 systems_i586 = ['seawolf']
 systems_x86 = ['alpine-3.14','alpine-3.15','debian-11','debian-10']
 targets = ['x86_64','arm64','arm32','i586','x86'] as String[]


### PR DESCRIPTION
- Updates to install additional packages to manage gcovr dependencies on arm32