### PR TITLE
XRT-2658: Fix issue with removed/deleted schedules being re-queued

### DIFF
--- a/src/c/scheduler.c
+++ b/src/c/scheduler.c
@@ -177,7 +177,7 @@ static void * iot_scheduler_thread (void * arg)
     iot_schedule_t * current = iot_schedule_queue_next (queue);
     if (current && current->start < iot_time_nsecs ()) // If a schedule and ready to run
     {
-      bool valid_current = atomic_load(&current->scheduled);
+      bool valid_current = atomic_load (&current->scheduled);
       if (atomic_load (&current->concurrent) || (atomic_load (&current->refs) == 1u)) // Check for concurrent execution
       {
         iot_schedule_add_ref (current);
@@ -187,7 +187,7 @@ static void * iot_scheduler_thread (void * arg)
           iot_component_unlock (&scheduler->component);
           current->run_cb (current->arg);
           iot_component_lock (&scheduler->component);
-          valid_current = atomic_load(&current->scheduled);
+          valid_current = atomic_load (&current->scheduled);
         }
         if (atomic_load (&current->sync)) // Run schedule directly
         {
@@ -210,7 +210,7 @@ static void * iot_scheduler_thread (void * arg)
             {
               iot_log_warn (scheduler->logger, "Scheduled event dropped for schedule #%" PRIu64, current->id);
             }
-            valid_current = atomic_load (&current->refs) > 1u && atomic_load(&current->scheduled);;
+            valid_current = atomic_load (&current->refs) > 1u && atomic_load (&current->scheduled);;
             iot_schedule_free (current);
           }
         }

--- a/src/c/scheduler.c
+++ b/src/c/scheduler.c
@@ -234,7 +234,7 @@ static void * iot_scheduler_thread (void * arg)
         /* Recalculate the next start time for the schedule */
         next = current->period + iot_time_nsecs ();
 
-        if (((current->repeat > 0u) && (--(current->repeat) == 0u))) // Last repetition
+        if ((current->repeat > 0u) && (--(current->repeat) == 0u)) // Last repetition
         {
           iot_log_trace (scheduler->logger, "Schedule #%" PRIu64 " now idle", current->id);
           iot_schedule_queue_remove (scheduler, current);

--- a/src/c/scheduler.c
+++ b/src/c/scheduler.c
@@ -210,7 +210,7 @@ static void * iot_scheduler_thread (void * arg)
             {
               iot_log_warn (scheduler->logger, "Scheduled event dropped for schedule #%" PRIu64, current->id);
             }
-            valid_current = atomic_load (&current->refs) > 1 && atomic_load(&current->scheduled);;
+            valid_current = atomic_load (&current->refs) > 1u && atomic_load(&current->scheduled);;
             iot_schedule_free (current);
           }
         }


### PR DESCRIPTION
The component is unlocked briefly within iot_scheduler_thread(). If iot_schedule_delete() is called on the current schedule during this time, there was potential for it to be immediately re-queued despite having been freed, which lead to a crash.

Now it keeps track of whether current->scheduled is still true after every component unlock. If not, then is marked as invalid and not re-queued or accessed again after current run

Have moved schedule->scheduled = false to queue_remove() instead of idle_add() function, as if iot_schedule_delete() receives a schedule that is still in the queue, it does not bother adding to idle before freeing.