### PR TITLE
XRT-2727 fix: Fixed buffer overflow when handling paths

### DIFF
--- a/src/c/file.c
+++ b/src/c/file.c
@@ -105,6 +105,10 @@ uint8_t * iot_file_read_binary (const char * path, size_t * len)
 bool iot_file_write_binary (const char * path, const uint8_t * binary, size_t len)
 {
   assert (path && binary);
+  if(len > PATH_MAX - 5)
+  {
+    return false;
+  }
   bool ok = false;
   char tmp_path[PATH_MAX];
   strncpy (tmp_path, path, PATH_MAX - 5);


### PR DESCRIPTION
True was being passed when it should be false