### PR TITLE
XRT 2749 feat: Add in iot_data_length function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,3 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
+- Added `iot_data_iter_size` function for determining number of elements for generic iterator

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,4 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
-- Added `iot_data_iter_size` function for determining number of elements for generic iterator
+- Added `iot_data_iterable_length` function for determining number of elements in generic iterable types

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,4 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
-- Added `iot_data_length` function for determining number of elements in a list, map, array, binary or vector
+- Added `iot_data_length` function for determining number of elements in iot_data object

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,4 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
-- Added `iot_data_length` function for determining number of elements in a list, map, array or vector
+- Added `iot_data_length` function for determining number of elements in a list, map, array, binary or vector

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,4 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
-- Added `iot_data_iterable_length` function for determining number of elements in generic iterable types
+- Added `iot_data_length` function for determining number of elements in a list, map or vector

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -379,4 +379,4 @@
 
 - Support added for Debian 12
 - Added `iot_data_iter_t` to allow for iteration over generic iterable types
-- Added `iot_data_length` function for determining number of elements in a list, map or vector
+- Added `iot_data_length` function for determining number of elements in a list, map, array or vector

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,7 +2055,7 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
- * @brief Get the number of elements in a list, map or vector
+ * @brief Get the number of elements in a list, map, array or vector
  *
  * @param data Input data
  * @return Number of elements

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,7 +2055,7 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
- * @brief Get the number of elements in a list, map, array or vector
+ * @brief Get the number of elements in a list, map, array, binary or vector
  *
  * @param data Input data
  * @return Number of elements

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,6 +2055,16 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
+ * @brief Get the number of elements in the underlying iterable data of an iterator
+ *
+ * The function returns the number of elements in the iterable data of an iterator, when the iterable data is of type list, map or vector
+ *
+ * @param iter Input iterator
+ * @return Number of elements in underlying interable data
+ */
+extern uint32_t iot_data_iter_size (const iot_data_iter_t * iter);
+
+/**
  * @brief Iterate to next iterable element
  *
  * The function to set the iterator to point to the next element in an iterable. On reaching the end of the iterable,

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,14 +2055,14 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
- * @brief Get the number of elements in the underlying iterable data of an iterator
+ * @brief Get the number of elements in an iterable data type
  *
- * The function returns the number of elements in the iterable data of an iterator, when the iterable data is of type list, map or vector
+ * The function returns the number of elements in a list, map or vector.
  *
- * @param iter Input iterator
- * @return Number of elements in underlying interable data
+ * @param iter Input iterable
+ * @return Number of elements
  */
-extern uint32_t iot_data_iter_size (const iot_data_iter_t * iter);
+extern uint32_t iot_data_iterable_length (const iot_data_t * iterable);
 
 /**
  * @brief Iterate to next iterable element

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,14 +2055,12 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
- * @brief Get the number of elements in an iterable data type
+ * @brief Get the number of elements in a list, map or vector
  *
- * The function returns the number of elements in a list, map or vector.
- *
- * @param iter Input iterable
+ * @param data Input data
  * @return Number of elements
  */
-extern uint32_t iot_data_iterable_length (const iot_data_t * iterable);
+extern uint32_t iot_data_length (const iot_data_t * data);
 
 /**
  * @brief Iterate to next iterable element

--- a/include/iot/data.h
+++ b/include/iot/data.h
@@ -2055,7 +2055,10 @@ extern const iot_data_t * iot_data_vector_find (const iot_data_t * vector, iot_d
 extern void iot_data_iter (const iot_data_t * iterable, iot_data_iter_t * iter);
 
 /**
- * @brief Get the number of elements in a list, map, array, binary or vector
+ * @brief Get the number of elements in an iot_data object
+ *
+ * This function returns the number of elements in an iot_data object.
+ * This is 1 for all data types other than lists, vectors, arrays, maps and binary types where it is the number of elements in each.
  *
  * @param data Input data
  * @return Number of elements

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3364,6 +3364,9 @@ uint32_t iot_data_length (const iot_data_t * data)
       length = impl->head ? impl->head->length : 0;
       break;
     }
+    case IOT_DATA_ARRAY:
+      length = ((const iot_data_array_t*) data)->length;
+      break;
     default:
       assert (false);
   }

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3345,21 +3345,21 @@ extern void iot_data_map_dump (iot_data_t * map)
 
 #endif
 
-uint32_t iot_data_iterable_length (const iot_data_t * iterable)
+uint32_t iot_data_length (const iot_data_t * data)
 {
-  assert (iterable);
+  assert (data);
   uint32_t length;
 
-  switch (iot_data_type(iterable))
+  switch (iot_data_type(data))
   {
     case IOT_DATA_VECTOR:
-      length = iot_data_vector_size (iterable);
+      length = iot_data_vector_size (data);
       break;
     case IOT_DATA_MAP:
-      length = iot_data_map_size (iterable);
+      length = iot_data_map_size (data);
       break;
     case IOT_DATA_LIST:
-      length = iot_data_list_length(iterable);
+      length = iot_data_list_length(data);
       break;
     default:
       assert (false);

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3364,6 +3364,7 @@ uint32_t iot_data_length (const iot_data_t * data)
       length = impl->head ? impl->head->length : 0;
       break;
     }
+    case IOT_DATA_BINARY:
     case IOT_DATA_ARRAY:
       length = ((const iot_data_array_t*) data)->length;
       break;

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3369,7 +3369,7 @@ uint32_t iot_data_length (const iot_data_t * data)
       length = ((const iot_data_array_t*) data)->length;
       break;
     default:
-      assert (false);
+      length = 1;
   }
 
   return length;

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3347,10 +3347,10 @@ extern void iot_data_map_dump (iot_data_t * map)
 
 uint32_t iot_data_length (const iot_data_t * data)
 {
-  assert (data);
-  uint32_t length;
+  assert (data && (data->type <= IOT_DATA_MAP));
+  uint32_t length = 1;
 
-  switch (iot_data_type(data))
+  switch (data->type)
   {
     case IOT_DATA_VECTOR:
       length = ((const iot_data_vector_t*) data)->size;
@@ -3369,7 +3369,7 @@ uint32_t iot_data_length (const iot_data_t * data)
       length = ((const iot_data_array_t*) data)->length;
       break;
     default:
-      length = 1;
+      break;
   }
 
   return length;

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3345,27 +3345,27 @@ extern void iot_data_map_dump (iot_data_t * map)
 
 #endif
 
-uint32_t iot_data_iter_size (const iot_data_iter_t * iter)
+uint32_t iot_data_iterable_length (const iot_data_t * iterable)
 {
-  assert (iter);
-  uint32_t size;
+  assert (iterable);
+  uint32_t length;
 
-  switch (iter->_type)
+  switch (iot_data_type(iterable))
   {
     case IOT_DATA_VECTOR:
-      size = iot_data_vector_size (iter->_iter.vector._vector);
+      length = iot_data_vector_size (iterable);
       break;
     case IOT_DATA_MAP:
-      size = iot_data_map_size (iter->_iter.map._map);
+      length = iot_data_map_size (iterable);
       break;
     case IOT_DATA_LIST:
-      size = iot_data_list_length(iter->_iter.list._list);
+      length = iot_data_list_length(iterable);
       break;
     default:
       assert (false);
   }
 
-  return size;
+  return length;
 }
 
 void iot_data_iter (const iot_data_t * data, iot_data_iter_t *iter)

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3353,14 +3353,17 @@ uint32_t iot_data_length (const iot_data_t * data)
   switch (iot_data_type(data))
   {
     case IOT_DATA_VECTOR:
-      length = iot_data_vector_size (data);
+      length = ((const iot_data_vector_t*) data)->size;
       break;
     case IOT_DATA_MAP:
-      length = iot_data_map_size (data);
+      length = ((const iot_data_map_t*) data)->size;
       break;
     case IOT_DATA_LIST:
-      length = iot_data_list_length(data);
+    {
+      const iot_data_list_t *impl = (const iot_data_list_t *) data;
+      length = impl->head ? impl->head->length : 0;
       break;
+    }
     default:
       assert (false);
   }

--- a/src/c/data.c
+++ b/src/c/data.c
@@ -3345,6 +3345,29 @@ extern void iot_data_map_dump (iot_data_t * map)
 
 #endif
 
+uint32_t iot_data_iter_size (const iot_data_iter_t * iter)
+{
+  assert (iter);
+  uint32_t size;
+
+  switch (iter->_type)
+  {
+    case IOT_DATA_VECTOR:
+      size = iot_data_vector_size (iter->_iter.vector._vector);
+      break;
+    case IOT_DATA_MAP:
+      size = iot_data_map_size (iter->_iter.map._map);
+      break;
+    case IOT_DATA_LIST:
+      size = iot_data_list_length(iter->_iter.list._list);
+      break;
+    default:
+      assert (false);
+  }
+
+  return size;
+}
+
 void iot_data_iter (const iot_data_t * data, iot_data_iter_t *iter)
 {
   iter->_type = data->type;

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -5429,9 +5429,9 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_array_iter_float64", test_data_array_iter_float64);
   CU_add_test (suite, "data_array_iter_bool", test_data_array_iter_bool);
   CU_add_test (suite, "data_list_size", test_list_size);
-  CU_add_test (suite, "data_iter_size_map", test_iterable_length_map);
-  CU_add_test (suite, "data_iter_size_vector", test_iterable_length_vector);
-  CU_add_test (suite, "data_iter_size_list", test_iterable_length_list);
+  CU_add_test (suite, "data_iterable_length_map", test_iterable_length_map);
+  CU_add_test (suite, "data_iterable_length_vector", test_iterable_length_vector);
+  CU_add_test (suite, "data_iterable_length_list", test_iterable_length_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);
   CU_add_test (suite, "data_list_copy", test_list_copy);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2351,49 +2351,37 @@ static void test_map_get (void)
   iot_data_free (map);
 }
 
-static void test_iter_size_map(void)
+static void test_iterable_length_map(void)
 {
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
 
-  iot_data_iter_t iter;
-
-  iot_data_iter(map, &iter);
-
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 0u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 0u);
   iot_data_string_map_add (map, "Key1", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 1u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 1u);
   iot_data_string_map_add (map, "Key2", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 2u);
 }
 
-static void test_iter_size_vector(void)
+static void test_iterable_length_vector(void)
 {
   iot_data_t * vector = iot_data_alloc_vector (2u);
 
-  iot_data_iter_t iter;
-
-  iot_data_iter(vector, &iter);
-
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
   iot_data_vector_add(vector, 0, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
   iot_data_vector_add(vector, 1, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
 }
 
-static void test_iter_size_list(void)
+static void test_iterable_length_list(void)
 {
   iot_data_t * list = iot_data_alloc_list ();
 
-  iot_data_iter_t iter;
-
-  iot_data_iter(list, &iter);
-
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 0u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 0u);
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 1u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 1u);
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 2u);
 }
 
 static void test_list_size (void)
@@ -5441,9 +5429,9 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_array_iter_float64", test_data_array_iter_float64);
   CU_add_test (suite, "data_array_iter_bool", test_data_array_iter_bool);
   CU_add_test (suite, "data_list_size", test_list_size);
-  CU_add_test (suite, "data_iter_size_map", test_iter_size_map);
-  CU_add_test (suite, "data_iter_size_vector", test_iter_size_vector);
-  CU_add_test (suite, "data_iter_size_list", test_iter_size_list);
+  CU_add_test (suite, "data_iter_size_map", test_iterable_length_map);
+  CU_add_test (suite, "data_iter_size_vector", test_iterable_length_vector);
+  CU_add_test (suite, "data_iter_size_list", test_iterable_length_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);
   CU_add_test (suite, "data_list_copy", test_list_copy);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2351,6 +2351,51 @@ static void test_map_get (void)
   iot_data_free (map);
 }
 
+static void test_iter_size_map(void)
+{
+  iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
+
+  iot_data_iter_t iter;
+
+  iot_data_iter(map, &iter);
+
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 0u);
+  iot_data_string_map_add (map, "Key1", iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 1u);
+  iot_data_string_map_add (map, "Key2", iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+}
+
+static void test_iter_size_vector(void)
+{
+  iot_data_t * vector = iot_data_alloc_vector (2u);
+
+  iot_data_iter_t iter;
+
+  iot_data_iter(vector, &iter);
+
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  iot_data_vector_add(vector, 0, iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+  iot_data_vector_add(vector, 1, iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+}
+
+static void test_iter_size_list(void)
+{
+  iot_data_t * list = iot_data_alloc_list ();
+
+  iot_data_iter_t iter;
+
+  iot_data_iter(list, &iter);
+
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 0u);
+  iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 1u);
+  iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
+  CU_ASSERT_EQUAL(iot_data_iter_size (&iter), 2u);
+}
+
 static void test_list_size (void)
 {
   iot_data_t * list = iot_data_alloc_list ();
@@ -5396,6 +5441,9 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_array_iter_float64", test_data_array_iter_float64);
   CU_add_test (suite, "data_array_iter_bool", test_data_array_iter_bool);
   CU_add_test (suite, "data_list_size", test_list_size);
+  CU_add_test (suite, "data_iter_size_map", test_iter_size_map);
+  CU_add_test (suite, "data_iter_size_vector", test_iter_size_vector);
+  CU_add_test (suite, "data_iter_size_list", test_iter_size_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);
   CU_add_test (suite, "data_list_copy", test_list_copy);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -5446,7 +5446,7 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_array_iter_float32", test_data_array_iter_float32);
   CU_add_test (suite, "data_array_iter_float64", test_data_array_iter_float64);
   CU_add_test (suite, "data_array_iter_bool", test_data_array_iter_bool);
-  CU_add_test (suite, "data_size", test_list_size);
+  CU_add_test (suite, "data_list_size", test_list_size);
   CU_add_test (suite, "data_length_map", test_data_length_map);
   CU_add_test (suite, "data_length_vector", test_data_length_vector);
   CU_add_test (suite, "data_length_array", test_data_length_array);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2362,6 +2362,15 @@ static void test_data_length_map(void)
   CU_ASSERT_EQUAL (iot_data_length (map), 2u)
 }
 
+static void test_data_length_binary(void)
+{
+  int8_t data[4] = {-1, -2, 3, 4};
+
+  iot_data_t * array = iot_data_alloc_binary(data, sizeof(data), IOT_DATA_REF);
+
+  CU_ASSERT_EQUAL (iot_data_length (array), 4u)
+}
+
 static void test_data_length_array(void)
 {
   int8_t data[4] = {-1, -2, 3, 4};
@@ -5441,6 +5450,7 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_length_map", test_data_length_map);
   CU_add_test (suite, "data_length_vector", test_data_length_vector);
   CU_add_test (suite, "data_length_array", test_data_length_array);
+  CU_add_test (suite, "data_length_binary", test_data_length_binary);
   CU_add_test (suite, "data_length_list", test_data_length_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2391,6 +2391,13 @@ static void test_data_length_vector(void)
   CU_ASSERT_EQUAL (iot_data_length (vector), 2u)
 }
 
+static void test_data_length_uint8(void)
+{
+  iot_data_t * uint8 = iot_data_alloc_ui8(3u);
+
+  CU_ASSERT_EQUAL (iot_data_length (uint8), 1u)
+}
+
 static void test_data_length_list(void)
 {
   iot_data_t * list = iot_data_alloc_list ();
@@ -5452,6 +5459,7 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_length_array", test_data_length_array);
   CU_add_test (suite, "data_length_binary", test_data_length_binary);
   CU_add_test (suite, "data_length_list", test_data_length_list);
+  CU_add_test (suite, "data_length_uint8", test_data_length_uint8);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);
   CU_add_test (suite, "data_list_copy", test_list_copy);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2355,11 +2355,11 @@ static void test_data_length_map(void)
 {
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
 
-  CU_ASSERT_EQUAL(iot_data_length (map), 0u);
+  CU_ASSERT_EQUAL (iot_data_length (map), 0u)
   iot_data_string_map_add (map, "Key1", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (map), 1u);
+  CU_ASSERT_EQUAL (iot_data_length (map), 1u)
   iot_data_string_map_add (map, "Key2", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (map), 2u);
+  CU_ASSERT_EQUAL (iot_data_length (map), 2u)
 }
 
 static void test_data_length_array(void)
@@ -2368,29 +2368,29 @@ static void test_data_length_array(void)
 
   iot_data_t * array = iot_data_alloc_array (data, sizeof(data), IOT_DATA_INT8, IOT_DATA_REF);
 
-  CU_ASSERT_EQUAL(iot_data_length (array), 4u);
+  CU_ASSERT_EQUAL (iot_data_length (array), 4u)
 }
 
 static void test_data_length_vector(void)
 {
   iot_data_t * vector = iot_data_alloc_vector (2u);
 
-  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
+  CU_ASSERT_EQUAL (iot_data_length (vector), 2u)
   iot_data_vector_add(vector, 0, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
+  CU_ASSERT_EQUAL (iot_data_length (vector), 2u)
   iot_data_vector_add(vector, 1, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
+  CU_ASSERT_EQUAL (iot_data_length (vector), 2u)
 }
 
 static void test_data_length_list(void)
 {
   iot_data_t * list = iot_data_alloc_list ();
 
-  CU_ASSERT_EQUAL(iot_data_length (list), 0u);
+  CU_ASSERT_EQUAL (iot_data_length (list), 0u)
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (list), 1u);
+  CU_ASSERT_EQUAL (iot_data_length (list), 1u)
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_length (list), 2u);
+  CU_ASSERT_EQUAL (iot_data_length (list), 2u)
 }
 
 static void test_list_size (void)

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2351,37 +2351,37 @@ static void test_map_get (void)
   iot_data_free (map);
 }
 
-static void test_iterable_length_map(void)
+static void test_data_length_map(void)
 {
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
 
-  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 0u);
+  CU_ASSERT_EQUAL(iot_data_length (map), 0u);
   iot_data_string_map_add (map, "Key1", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 1u);
+  CU_ASSERT_EQUAL(iot_data_length (map), 1u);
   iot_data_string_map_add (map, "Key2", iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (map), 2u);
+  CU_ASSERT_EQUAL(iot_data_length (map), 2u);
 }
 
-static void test_iterable_length_vector(void)
+static void test_data_length_vector(void)
 {
   iot_data_t * vector = iot_data_alloc_vector (2u);
 
-  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
+  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
   iot_data_vector_add(vector, 0, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
+  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
   iot_data_vector_add(vector, 1, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (vector), 2u);
+  CU_ASSERT_EQUAL(iot_data_length (vector), 2u);
 }
 
-static void test_iterable_length_list(void)
+static void test_data_length_list(void)
 {
   iot_data_t * list = iot_data_alloc_list ();
 
-  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 0u);
+  CU_ASSERT_EQUAL(iot_data_length (list), 0u);
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 1u);
+  CU_ASSERT_EQUAL(iot_data_length (list), 1u);
   iot_data_list_tail_push(list, iot_data_alloc_ui32 (1u));
-  CU_ASSERT_EQUAL(iot_data_iterable_length (list), 2u);
+  CU_ASSERT_EQUAL(iot_data_length (list), 2u);
 }
 
 static void test_list_size (void)
@@ -5428,10 +5428,10 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_array_iter_float32", test_data_array_iter_float32);
   CU_add_test (suite, "data_array_iter_float64", test_data_array_iter_float64);
   CU_add_test (suite, "data_array_iter_bool", test_data_array_iter_bool);
-  CU_add_test (suite, "data_list_size", test_list_size);
-  CU_add_test (suite, "data_iterable_length_map", test_iterable_length_map);
-  CU_add_test (suite, "data_iterable_length_vector", test_iterable_length_vector);
-  CU_add_test (suite, "data_iterable_length_list", test_iterable_length_list);
+  CU_add_test (suite, "data_size", test_list_size);
+  CU_add_test (suite, "data_length_map", test_data_length_map);
+  CU_add_test (suite, "data_length_vector", test_data_length_vector);
+  CU_add_test (suite, "data_length_list", test_data_length_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);
   CU_add_test (suite, "data_list_copy", test_list_copy);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2362,6 +2362,15 @@ static void test_data_length_map(void)
   CU_ASSERT_EQUAL(iot_data_length (map), 2u);
 }
 
+static void test_data_length_array(void)
+{
+  int8_t data[4] = {-1, -2, 3, 4};
+
+  iot_data_t * array = iot_data_alloc_array (data, sizeof(data), IOT_DATA_INT8, IOT_DATA_REF);
+
+  CU_ASSERT_EQUAL(iot_data_length (array), 4u);
+}
+
 static void test_data_length_vector(void)
 {
   iot_data_t * vector = iot_data_alloc_vector (2u);
@@ -5431,6 +5440,7 @@ void cunit_data_test_init (void)
   CU_add_test (suite, "data_size", test_list_size);
   CU_add_test (suite, "data_length_map", test_data_length_map);
   CU_add_test (suite, "data_length_vector", test_data_length_vector);
+  CU_add_test (suite, "data_length_array", test_data_length_array);
   CU_add_test (suite, "data_length_list", test_data_length_list);
   CU_add_test (suite, "data_list_free", test_list_free);
   CU_add_test (suite, "data_list_iter", test_list_iter);

--- a/src/c/utests/data/data.c
+++ b/src/c/utests/data/data.c
@@ -2351,7 +2351,7 @@ static void test_map_get (void)
   iot_data_free (map);
 }
 
-static void test_data_length_map(void)
+static void test_data_length_map (void)
 {
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
 
@@ -2362,7 +2362,7 @@ static void test_data_length_map(void)
   CU_ASSERT_EQUAL (iot_data_length (map), 2u)
 }
 
-static void test_data_length_binary(void)
+static void test_data_length_binary (void)
 {
   int8_t data[4] = {-1, -2, 3, 4};
 
@@ -2371,7 +2371,7 @@ static void test_data_length_binary(void)
   CU_ASSERT_EQUAL (iot_data_length (array), 4u)
 }
 
-static void test_data_length_array(void)
+static void test_data_length_array (void)
 {
   int8_t data[4] = {-1, -2, 3, 4};
 
@@ -2380,7 +2380,7 @@ static void test_data_length_array(void)
   CU_ASSERT_EQUAL (iot_data_length (array), 4u)
 }
 
-static void test_data_length_vector(void)
+static void test_data_length_vector (void)
 {
   iot_data_t * vector = iot_data_alloc_vector (2u);
 
@@ -2391,14 +2391,14 @@ static void test_data_length_vector(void)
   CU_ASSERT_EQUAL (iot_data_length (vector), 2u)
 }
 
-static void test_data_length_uint8(void)
+static void test_data_length_uint8 (void)
 {
   iot_data_t * uint8 = iot_data_alloc_ui8(3u);
 
   CU_ASSERT_EQUAL (iot_data_length (uint8), 1u)
 }
 
-static void test_data_length_list(void)
+static void test_data_length_list (void)
 {
   iot_data_t * list = iot_data_alloc_list ();
 


### PR DESCRIPTION
Functionality required for alternative approach to bug fix https://github.com/IOTechSystems/xrt/pull/1791 whereby XRT crashes on attempted transform of rebirth_json. This function would then be used to make the sparkplug transforms accept both lists and vectors for complex data types. 

Happy to discuss if this is the right approach as I realise slightly odd to be getting the 'size' of an iterator.
