### PR TITLE
EB-3088 fix zero-length file read

### DIFF
--- a/src/c/file.c
+++ b/src/c/file.c
@@ -94,9 +94,12 @@ uint8_t * iot_file_read_binary (const char * path, size_t * len)
     {
       rewind (fd);
       ret = malloc (size + 1u); // Allocate extra byte so can be NULL terminated if a string
-      size_t items = fread (ret, size, 1u, fd);
-      assert (items == 1);
-      (void) items;
+      if (size)
+      {
+        size_t items = fread (ret, size, 1u, fd);
+        assert (items == 1);
+        (void) items;
+      }
       ret[size] = 0; // String NULL terminator
     }
     fclose (fd);


### PR DESCRIPTION
`fread()` returns zero when reading a zero-length file, which trips our assert if it's a debug build. But in this case we don't need to do the read at all.