### PR TITLE
XRT-3444: Return stats only for whitelisted components

### DIFF
--- a/include/iot/container.h
+++ b/include/iot/container.h
@@ -154,10 +154,11 @@ extern iot_data_t * iot_container_component_read (iot_container_t * cont, const 
 /**
  * @brief Get component stats
  *
- * @param cont  Pointer to a container
- * @return      Data map of component name to stats
+ * @param cont                    Pointer to a container
+ * @param whitelisted_components  Pointer to a vector containing the names of components whose stats to publish
+ * @return                        Data map of component name to stats
  */
-extern iot_data_t * iot_container_stats (iot_container_t * cont);
+extern iot_data_t * iot_container_stats (iot_container_t * cont, iot_data_t * whitelisted_components);
 
 #ifdef __cplusplus
 }

--- a/src/c/container.c
+++ b/src/c/container.c
@@ -482,6 +482,7 @@ iot_data_t * iot_container_component_read (iot_container_t * cont, const char * 
 iot_data_t * iot_container_stats (iot_container_t * cont, iot_data_t * whitelisted_components)
 {
   assert (cont);
+  assert (whitelisted_components);
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
   iot_data_vector_iter_t sub_iter;
   pthread_rwlock_rdlock (&cont->lock);

--- a/src/c/container.c
+++ b/src/c/container.c
@@ -479,16 +479,16 @@ iot_data_t * iot_container_component_read (iot_container_t * cont, const char * 
   return data;
 }
 
-iot_data_t * iot_container_stats (iot_container_t * cont)
+iot_data_t * iot_container_stats (iot_container_t * cont, iot_data_t * whitelisted_components)
 {
   assert (cont);
   iot_data_t * map = iot_data_alloc_map (IOT_DATA_STRING);
-  iot_data_list_iter_t iter;
+  iot_data_vector_iter_t sub_iter;
   pthread_rwlock_rdlock (&cont->lock);
-  iot_data_list_iter (cont->components, &iter);
-  while (iot_data_list_iter_next (&iter))
+  iot_data_vector_iter (whitelisted_components, &sub_iter);
+  while (iot_data_vector_iter_next (&sub_iter))
   {
-    iot_component_t * comp = (iot_component_t *) iot_data_list_iter_pointer_value (&iter); // double check cast
+    iot_component_t * comp = iot_container_find_component (cont, iot_data_vector_iter_string_value (&sub_iter));
     iot_data_t * stats = iot_component_stats (comp);
     if (stats) iot_data_map_add (map, iot_data_alloc_string (comp->name, IOT_DATA_COPY), stats);
   }


### PR DESCRIPTION
This PR changes `iot_container_stats` to return stats only for whitelisted components passed to it instead of every component.