### PR TITLE
XRT-3646: Inline yield instruction on arm

### DIFF
--- a/src/c/data.c
+++ b/src/c/data.c
@@ -16,8 +16,7 @@
   #include <immintrin.h>
   #define cpu_relax() _mm_pause()
 #elif defined(__aarch64__) || defined(__arm__)
-  #include <arm_acle.h>
-  #define cpu_relax() __yield()
+  #define cpu_relax() __asm__ __volatile__("yield" ::: "memory")
 #endif
 
 #if !defined DEBUG_MEMORY


### PR DESCRIPTION
GCC does not appear to support the `__yield()` ACLE intrinsic so we can inline it directly. ARM [docs](https://github.com/ARM-software/acle/releases) state that `yield` is supported on ARMv7 and ARMv8+ so this shouldn't cause problems. 